### PR TITLE
Fixed an issue in the writeScriptCallingBack function where single quotes (') in the callback string caused JavaScript execution errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Forked from https://github.com/EdgarDegas/DSBridge-Swift
 
 [^1]: Designed by [Freepik](https://freepik.com)
 
-[简体中文版](https://github.com/EdgarDegas/DSBridge-Swift/blob/main/README.zh-Hans.md)
+[简体中文版](https://github.com/1245040330/DSBridge-Swift/blob/main/README.zh-Hans.md)
 
 DSBridge-Swift is a [DSBridge-iOS](https://github.com/wendux/DSBridge-IOS) fork in Swift. It allows developers to send method calls back and forth between Swift and JavaScript.
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
+
+#V1.0.6
+Optimized dsbridge
+
+New Features Added support for returning plain strings
+
+Fixes Fixed an issue in the writeScriptCallingBack function where single quotes (') in the callback string caused JavaScript execution errors
+
+Forked from https://github.com/EdgarDegas/DSBridge-Swift
+@EdgarDegas
+---
+
 [^1]
 
 <picture>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-#V1.0.6
+# V1.0.6
 Optimized dsbridge
 
 New Features Added support for returning plain strings

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -1,3 +1,10 @@
+# V1.0.6
+优化 dsbridge
+新增 支持返回纯字符串
+修复writeScriptCallingBack函数在拼接回调时 字符串中有单引号 ('')导致js端执行报错
+Fork 自 https://github.com/EdgarDegas/DSBridge-Swift
+@EdgarDegas
+
 [^1]
 
 <picture>

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -1,9 +1,9 @@
 # V1.0.6
-优化 dsbridge
-新增 支持返回纯字符串
-修复writeScriptCallingBack函数在拼接回调时 字符串中有单引号 ('')导致js端执行报错
-Fork 自 https://github.com/EdgarDegas/DSBridge-Swift
-@EdgarDegas
+优化 dsbridge  
+新增 支持返回纯字符串  
+修复writeScriptCallingBack函数在拼接回调时 字符串中有单引号 ('')导致js端执行报错  
+Fork 自 https://github.com/EdgarDegas/DSBridge-Swift  
+@EdgarDegas  
 
 [^1]
 

--- a/Sources/DSBridge/Keystone.swift
+++ b/Sources/DSBridge/Keystone.swift
@@ -152,7 +152,7 @@ open class Keystone: KeystoneProtocol {
         let completed = response.completed
         do {
             var encoded = "";
-            if data is String {
+            if let stringData = data as? String {
                 //如果是字符串 不执行json序列化
                 encoded = data;
             }else{

--- a/Sources/DSBridge/Keystone.swift
+++ b/Sources/DSBridge/Keystone.swift
@@ -34,7 +34,6 @@ open class Keystone: KeystoneProtocol {
     open lazy var javaScriptEvaluator: any JavaScriptEvaluating =
         JavaScriptEvaluator
     { [weak self] script in
-        print(script)
         self?.evaluateJavaScript(script)
     }
     
@@ -177,7 +176,6 @@ open class Keystone: KeystoneProtocol {
             try {
                 let encodedData = "\(encodedData)";
                 let json =JSON.parse(decodeURIComponent(encodedData));
-                console.log(json)
                 \(functionName)(json);
                 \(deletingScript);
             } catch(e) {

--- a/Sources/DSBridge/Keystone.swift
+++ b/Sources/DSBridge/Keystone.swift
@@ -152,7 +152,8 @@ open class Keystone: KeystoneProtocol {
         let data = response.data
         let completed = response.completed
         do {
-            let encoded = try jsonSerializer.serialize(data)
+            var encoded = try jsonSerializer.serialize(data)
+            encoded = clStringConvert(encoded)
             let deletingScript = writeDeletingScript(
                 for: functionName, if: completed
             )
@@ -195,6 +196,41 @@ open class Keystone: KeystoneProtocol {
                 ""
             }
         }
+         //判断字符串是否为json
+    func isValidJSON(_ string: String) -> Bool{
+        if let data = string.data(using: .utf8){
+            do{
+                _ = try JSONSerialization.jsonObject(with: data,options: []);
+                return true;
+            }catch{
+                return false;
+            }
+        }
+        return false;
+    }
+    
+    //添加转义
+    func addEscapeCharactersToJSONString(_ string: String) -> String{
+        var escapedString = string
+        // 添加转义符号，转义常见的特殊字符
+        escapedString = escapedString.replacingOccurrences(of: "\\", with: "\\\\")
+        escapedString = escapedString.replacingOccurrences(of: "\"", with: "\\\"")
+        escapedString = escapedString.replacingOccurrences(of: "\n", with: "\\n")
+        escapedString = escapedString.replacingOccurrences(of: "\r", with: "\\r")
+        escapedString = escapedString.replacingOccurrences(of: "\t", with: "\\t")
+        escapedString = escapedString.replacingOccurrences(of: "\u{2028}", with: "\\u2028") // Line separator
+        escapedString = escapedString.replacingOccurrences(of: "\u{2029}", with: "\\u2029") // Paragraph separator
+        return escapedString
+    }
+    
+    //字符串转换
+    func clStringConvert(_ string:String) -> String{
+        if(isValidJSON(string)){
+            return addEscapeCharactersToJSONString(string);
+        }else{
+            return string;
+        }
+    }
     }
     
     open func handleRawInvocation(

--- a/Sources/DSBridge/Keystone.swift
+++ b/Sources/DSBridge/Keystone.swift
@@ -154,7 +154,7 @@ open class Keystone: KeystoneProtocol {
             var encoded = "";
             if let stringData = data as? String {
                 //如果是字符串 不执行json序列化
-                encoded = stringData;
+                encoded = stringData.replacingOccurrences(of: "\"", with: "\\\"");
             }else{
                 encoded = try jsonSerializer.serialize(data)
             }

--- a/Sources/DSBridge/Keystone.swift
+++ b/Sources/DSBridge/Keystone.swift
@@ -180,13 +180,18 @@ open class Keystone: KeystoneProtocol {
             deletingScript: String
         ) -> String {
             """
-            try {
                 let encodedData = "\(encodedData)";
-                let json =JSON.parse(decodeURIComponent(encodedData));
-                \(functionName)(json);
-                \(deletingScript);
+                let params = "";
+            try {
+                params =JSON.parse(decodeURIComponent(encodedData));
             } catch(e) {
-            
+                params =decodeURIComponent(encodedData);
+            }
+            try{
+                \(functionName)(params);
+                \(deletingScript);
+            } catch(e){
+                
             }
             """
         }

--- a/Sources/DSBridge/Keystone.swift
+++ b/Sources/DSBridge/Keystone.swift
@@ -173,7 +173,9 @@ open class Keystone: KeystoneProtocol {
         ) -> String {
             """
             try {
-                \(functionName)(JSON.parse(decodeURIComponent(`\(encodedData)`)));
+            let json =JSON.parse(decodeURIComponent("\(encodedData)"));
+            console.log(json)
+                \(functionName)(json);
                 \(deletingScript);
             } catch(e) {
             

--- a/Sources/DSBridge/Keystone.swift
+++ b/Sources/DSBridge/Keystone.swift
@@ -217,17 +217,14 @@ open class Keystone: KeystoneProtocol {
     }
     
     //添加转义
-    func addEscapeCharactersToJSONString(_ string: String) -> String{
-        var escapedString = string
-        // 添加转义符号，转义常见的特殊字符
-        escapedString = escapedString.replacingOccurrences(of: "\\", with: "\\\\")
-        escapedString = escapedString.replacingOccurrences(of: "\"", with: "\\\"")
-        escapedString = escapedString.replacingOccurrences(of: "\n", with: "\\n")
-        escapedString = escapedString.replacingOccurrences(of: "\r", with: "\\r")
-        escapedString = escapedString.replacingOccurrences(of: "\t", with: "\\t")
-        escapedString = escapedString.replacingOccurrences(of: "\u{2028}", with: "\\u2028") // Line separator
-        escapedString = escapedString.replacingOccurrences(of: "\u{2029}", with: "\\u2029") // Paragraph separator
-        return escapedString
+      func addEscapeCharactersToJSONString(_ string: String) -> String {
+        let encoder = JSONEncoder()
+        if let data = try? encoder.encode(string),
+           let jsonEscaped = String(data: data, encoding: .utf8) {
+            // 去掉两边的双引号（因为 encode(string) 会包一层引号）
+            return String(jsonEscaped.dropFirst().dropLast())
+        }
+        return string
     }
     
     //字符串转换

--- a/Sources/DSBridge/Keystone.swift
+++ b/Sources/DSBridge/Keystone.swift
@@ -34,6 +34,7 @@ open class Keystone: KeystoneProtocol {
     open lazy var javaScriptEvaluator: any JavaScriptEvaluating =
         JavaScriptEvaluator
     { [weak self] script in
+        print(script)
         self?.evaluateJavaScript(script)
     }
     

--- a/Sources/DSBridge/Keystone.swift
+++ b/Sources/DSBridge/Keystone.swift
@@ -173,7 +173,7 @@ open class Keystone: KeystoneProtocol {
         ) -> String {
             """
             try {
-                \(functionName)(JSON.parse(decodeURIComponent("\(encodedData)")));
+                \(functionName)(JSON.parse(decodeURIComponent(`\(encodedData)`)));
                 \(deletingScript);
             } catch(e) {
             

--- a/Sources/DSBridge/Keystone.swift
+++ b/Sources/DSBridge/Keystone.swift
@@ -180,17 +180,14 @@ open class Keystone: KeystoneProtocol {
             deletingScript: String
         ) -> String {
             """
-                let encodedData = "\(encodedData)";
-                let params = "";
-            try {
-                params =JSON.parse(decodeURIComponent(encodedData));
-            } catch(e) {
-                params =decodeURIComponent(encodedData);
-            }
             try{
-                \(functionName)(params);
-                \(deletingScript);
+                \(functionName)(JSON.parse(decodeURIComponent("\(encodedData)")));
             } catch(e){
+                \(functionName)(decodeURIComponent("\(encodedData)"));
+            }
+            try {
+                \(deletingScript);
+            } catch(e) {
                 
             }
             """

--- a/Sources/DSBridge/Keystone.swift
+++ b/Sources/DSBridge/Keystone.swift
@@ -151,7 +151,14 @@ open class Keystone: KeystoneProtocol {
         let data = response.data
         let completed = response.completed
         do {
-            var encoded = try jsonSerializer.serialize(data)
+            var encoded = "";
+            if data is String {
+                //如果是字符串 不执行json序列化
+                encoded = data;
+            }else{
+                encoded = try jsonSerializer.serialize(data)
+            }
+             
             encoded = clStringConvert(encoded)
             let deletingScript = writeDeletingScript(
                 for: functionName, if: completed

--- a/Sources/DSBridge/Keystone.swift
+++ b/Sources/DSBridge/Keystone.swift
@@ -154,7 +154,7 @@ open class Keystone: KeystoneProtocol {
             var encoded = "";
             if let stringData = data as? String {
                 //如果是字符串 不执行json序列化
-                encoded = data;
+                encoded = stringData;
             }else{
                 encoded = try jsonSerializer.serialize(data)
             }

--- a/Sources/DSBridge/Keystone.swift
+++ b/Sources/DSBridge/Keystone.swift
@@ -173,8 +173,9 @@ open class Keystone: KeystoneProtocol {
         ) -> String {
             """
             try {
-            let json =JSON.parse(decodeURIComponent("\(encodedData)"));
-            console.log(json)
+                let encodedData = "\(encodedData)";
+                let json =JSON.parse(decodeURIComponent(encodedData));
+                console.log(json)
                 \(functionName)(json);
                 \(deletingScript);
             } catch(e) {

--- a/Sources/DSBridge/Keystone.swift
+++ b/Sources/DSBridge/Keystone.swift
@@ -173,7 +173,7 @@ open class Keystone: KeystoneProtocol {
         ) -> String {
             """
             try {
-                \(functionName)(JSON.parse(decodeURIComponent('\(encodedData)')));
+                \(functionName)(JSON.parse(decodeURIComponent("\(encodedData)")));
                 \(deletingScript);
             } catch(e) {
             


### PR DESCRIPTION



**优化** dsbridge  
**新增** 支持返回纯字符串  
**修复**writeScriptCallingBack函数在拼接回调时  字符串中有单引号 ('')导致js端执行报错
Fork 自 [https://github.com/EdgarDegas/DSBridge-Swift](url)
@EdgarDegas 


**Optimized** dsbridge

**New Features**  Added support for returning plain strings

**Fixes** Fixed an issue in the writeScriptCallingBack function where single quotes (') in the callback string caused JavaScript execution errors

Forked from [https://github.com/EdgarDegas/DSBridge-Swift](https://github.com/1245040330/DSBridge-Swift/url)
@EdgarDegas 








