### PR TITLE
Fix: Escape special characters in strings passed to JSON.parse

### DIFF
--- a/Sources/DSBridge/Keystone.swift
+++ b/Sources/DSBridge/Keystone.swift
@@ -171,13 +171,14 @@ open class Keystone: KeystoneProtocol {
             encodedData: String,
             deletingScript: String
         ) -> String {
-            """
-            try {
-                \(functionName)(JSON.parse(decodeURIComponent('\(encodedData)')));
-                \(deletingScript);
-            } catch(e) {
-            
-            }
+            let encodedString = encodedData.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? "{}"
+            return """
+                try {
+                    \(functionName)(JSON.parse(decodeURIComponent('\(encodedString)')));
+                    \(deletingScript);
+                } catch(e) {
+                
+                }
             """
         }
         


### PR DESCRIPTION
JSON.parse will consistently fail if the string passed to JavaScript contains unescaped special characters, such as single or double quotes.